### PR TITLE
Include BigDecimal as supported type

### DIFF
--- a/lib/eav_hashes/eav_entry.rb
+++ b/lib/eav_hashes/eav_entry.rb
@@ -30,7 +30,8 @@ module ActiveRecord
           :Boolean    => 6, # For code readability
           :TrueClass  => 6,
           :FalseClass => 6,
-          :Object     => 7 # anything else (including Hashes, Arrays) will be serialized to yaml and saved as Object
+          :Object     => 7, # anything else (including Hashes, Arrays) will be serialized to yaml and saved as Object
+          :BigDecimal => 8,
       }
 
       # Does some sanity checks.
@@ -120,6 +121,8 @@ module ActiveRecord
             @value = Rational @value
           when SUPPORTED_TYPES[:Boolean]
             @value = (@value == "true")
+          when SUPPORTED_TYPES[:BigDecimal]
+            @value = BigDecimal(@value)
           else
             @value
         end

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -12,7 +12,8 @@ p.tech_specs << {
   "An Object"   => CustomTestObject.new(42),
   "False"       => false,
   "True"        => true,
-  :symbolic_key => "This key is SYMBOLIC!!!!!1!!"
+  :symbolic_key => "This key is SYMBOLIC!!!!!1!!",
+  "A BigDecimal"=> BigDecimal("3.888")
 }
 
 p2 = Product.new

--- a/spec/lib/eav_hashes/eav_hash_spec.rb
+++ b/spec/lib/eav_hashes/eav_hash_spec.rb
@@ -91,6 +91,10 @@ describe "EavHash/EavEntry" do
         it "preserves user-defined value types" do
             expect(p1.tech_specs["An Object"]).to be_a_kind_of CustomTestObject
         end
+
+        it "preserves BigDecimal value types" do
+            expect(p1.tech_specs["A BigDecimal"]).to be_a_kind_of BigDecimal
+        end
     end
 
     describe "preserves values between serialization and deserialization" do
@@ -136,6 +140,10 @@ describe "EavHash/EavEntry" do
 
         it "preserves user-defined values" do
             expect(p1.tech_specs["An Object"].test_value).to eq(42)
+        end
+
+        it "preserves BigDecimal values" do
+            expect(p1.tech_specs["A BigDecimal"]).to eq(3.888)
         end
     end
 


### PR DESCRIPTION
`eavh_hashes` has a table for the additional attributes belonging to each model. The `value` column is that table stores serialized values for _unknown_ types like `BigDecimal`.

As `BigDecimal('2.123')` is stored `"--- !ruby/object:BigDecimal 18:0.2123e1\n"` using that value doesn't work well making comparisons inside queries.

To solve we add `BigDecimal` as a _known_ type for eavh_hashes. The value is stored as it is without object serialization